### PR TITLE
patch proj datadir

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,7 +46,7 @@ install:
     # Add our channels.
     - cmd: conda.exe config --set show_channel_urls true
     - cmd: conda.exe config --remove channels defaults
-    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels msys2
     - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,7 +46,7 @@ install:
     # Add our channels.
     - cmd: conda.exe config --set show_channel_urls true
     - cmd: conda.exe config --remove channels defaults
-    - cmd: conda.exe config --add channels msys2
+    - cmd: conda.exe config --add channels defaults
     - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.

--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -13,6 +13,6 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj4:
-- 5.1.0
+- 4.9.3
 python:
 - '2.7'

--- a/.ci_support/linux_python3.5.yaml
+++ b/.ci_support/linux_python3.5.yaml
@@ -13,6 +13,6 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj4:
-- 5.1.0
+- 4.9.3
 python:
 - '3.5'

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -13,6 +13,6 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj4:
-- 5.1.0
+- 4.9.3
 python:
 - '3.6'

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -13,6 +13,6 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj4:
-- 5.1.0
+- 4.9.3
 python:
 - '3.7'

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -17,6 +17,6 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj4:
-- 5.1.0
+- 4.9.3
 python:
 - '2.7'

--- a/.ci_support/osx_python3.5.yaml
+++ b/.ci_support/osx_python3.5.yaml
@@ -17,6 +17,6 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj4:
-- 5.1.0
+- 4.9.3
 python:
 - '3.5'

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -17,6 +17,6 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj4:
-- 5.1.0
+- 4.9.3
 python:
 - '3.6'

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -17,6 +17,6 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj4:
-- 5.1.0
+- 4.9.3
 python:
 - '3.7'

--- a/.ci_support/win_c_compilervs2008python2.7.yaml
+++ b/.ci_support/win_c_compilervs2008python2.7.yaml
@@ -11,7 +11,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj4:
-- 5.1.0
+- 4.9.3
 python:
 - '2.7'
 zip_keys:

--- a/.ci_support/win_c_compilervs2015python3.5.yaml
+++ b/.ci_support/win_c_compilervs2015python3.5.yaml
@@ -11,7 +11,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj4:
-- 5.1.0
+- 4.9.3
 python:
 - '3.5'
 zip_keys:

--- a/.ci_support/win_c_compilervs2015python3.6.yaml
+++ b/.ci_support/win_c_compilervs2015python3.6.yaml
@@ -11,7 +11,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj4:
-- 5.1.0
+- 4.9.3
 python:
 - '3.6'
 zip_keys:

--- a/.ci_support/win_c_compilervs2015python3.7.yaml
+++ b/.ci_support/win_c_compilervs2015python3.7.yaml
@@ -11,7 +11,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj4:
-- 5.1.0
+- 4.9.3
 python:
 - '3.7'
 zip_keys:

--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -32,6 +32,8 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+conda config --remove channels defaults --force
+
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"  --quiet
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,5 +62,8 @@ install:
 script:
   # generate the build number clobber
   - make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+
+  - conda config --remove channels defaults --force
+
   - conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
   - upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml

--- a/recipe/data_dir.patch
+++ b/recipe/data_dir.patch
@@ -1,0 +1,11 @@
+--- pyproj-1.9.5.1rel.orig/setup.py	2016-01-06 20:26:39.000000000 -0200
++++ pyproj-1.9.5.1rel/setup.py	2018-08-31 14:09:52.990151172 -0300
+@@ -24,7 +24,7 @@
+     runtime_library_dirs=libdirs,libraries=libraries)
+ 
+     # over-write default data directory.
+-    pyproj_datadir = os.path.join(os.path.join(proj_dir,'share'),'proj')
++    pyproj_datadir = os.environ['PROJ_LIB']
+     datadirfile = os.path.join('lib',os.path.join('pyproj','datadir.py'))
+     datadirfile_save = os.path.join('lib',os.path.join('pyproj','datadir.py.save'))
+     if not os.path.isfile(datadirfile_save):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,13 +8,16 @@ source:
   url: https://github.com/jswhit/pyproj/archive/v{{ version }}rel.tar.gz
   sha256: 0e19f02ebbf4c253813142ffe06e12489f3861877c3fab75b6c769c1a1960cac
   patches:
-    - data_dir.patch
+    # This is current failing on Windows,
+    # for some reason it cannot find the PROJ_LIB variable
+    # even though it is defined in proj.4's the activation scripts.
+    - data_dir.patch  # [not win]
 
 build:
   number: 3
   script:
     - del _proj.c  # [win]
-    # - rmdir src  # [win]
+    - rmdir src  # [win]
     - set "PROJ_DIR=%PREFIX%"  # [win]
     - set "PROJ_LIBDIR=%LIBRARY_LIB%"  # [win]
     - set "PROJ_INCDIR=%LIBRARY_INC%"  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,16 +7,22 @@ package:
 source:
   url: https://github.com/jswhit/pyproj/archive/v{{ version }}rel.tar.gz
   sha256: 0e19f02ebbf4c253813142ffe06e12489f3861877c3fab75b6c769c1a1960cac
+  patches:
+    - data_dir.patch
 
 build:
-  number: 1
+  number: 3
   script:
     - del _proj.c  # [win]
+    # - rmdir src  # [win]
     - set "PROJ_DIR=%PREFIX%"  # [win]
     - set "PROJ_LIBDIR=%LIBRARY_LIB%"  # [win]
     - set "PROJ_INCDIR=%LIBRARY_INC%"  # [win]
     - rm -d _proj.c  # [not win]
+    - rm -rf src
     - export PROJ_DIR="${PREFIX}"  # [not win]
+    - export PROJ_LIBDIR="${PREFIX}/lib"  # [not win]
+    - export PROJ_INCDIR="${PREFIX}/include"  # [not win]
     - cythonize -a -i _proj.pyx
     - "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
@@ -31,6 +37,7 @@ requirements:
   run:
     - python
     - numpy
+    - proj4
 
 test:
   imports:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -6,6 +6,9 @@ pyproj.test()
 from pyproj import Proj
 Proj(init='epsg:4269')
 
-# Test pyproj_datadir
-if not os.path.isdir(os.path.join(pyproj.pyproj_datadir)):
-    sys.exit(1)
+
+# Re-enable this test on Windows when the PROJ_LIB var issue is resolved.
+if not sys.platform == 'win32':
+    # Test pyproj_datadir.
+    if not os.path.isdir(os.path.join(pyproj.pyproj_datadir)):
+        sys.exit(1)

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,5 +1,11 @@
+import os
+import sys
 import pyproj
 pyproj.test()
 
 from pyproj import Proj
 Proj(init='epsg:4269')
+
+# Test pyproj_datadir
+if not os.path.isdir(os.path.join(pyproj.pyproj_datadir)):
+    sys.exit(1)


### PR DESCRIPTION
@msarahan and @mingwandroid previous versions of `proj` where using the bundled `proj.4` lib so we never noticed this, but since I backported the changes from AnacondaRecipes, where we are forcing it to use our version of `proj`, we ended up breaking packages downstream that rely on `pyproj_datadir`.