### PR TITLE
allow for base install

### DIFF
--- a/recipe/data_dir.patch
+++ b/recipe/data_dir.patch
@@ -13,7 +13,7 @@
          shutil.copyfile(datadirfile, datadirfile_save)
      f = open(datadirfile,'w')
 -    f.write('pyproj_datadir="%s"\n' % pyproj_datadir)
-+    f.write("import os; pyproj_datadir = os.environ['PROJ_LIB']")
++    f.write("import os; pyproj_datadir = os.environ.get('PROJ_LIB', '')")
      f.close()
  
      extensions = [pyprojext]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - data_dir.patch
 
 build:
-  number: 4
+  number: 5
   script:
     - del _proj.c  # [win]
     - rmdir src  # [win]


### PR DESCRIPTION
@jGaboardi it looks like only `basemap` needs uses `pyproj.datadir` so I'll set it to an empty string when it is not available, that should "fix" your case there.

Note that I'm uncertain if other packages uses `pyproj.datadir` and those, `basemap` included, will be broken if not installed inside an env.