### PR TITLE
Remove 4s from package/library names

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 92b8cf0703c25f4e197ec8696b1be567ebb33cb8ba542956142a61df6bf1b766
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<35]
   script:
     - "{{ PYTHON }} -m pip install . --no-deps -vv"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,10 +21,10 @@ requirements:
     - python
     - pip
     - cython
-    - proj4
+    - proj
   run:
     - python
-    - proj4
+    - proj
 
 test:
   imports:
@@ -34,7 +34,7 @@ about:
   home: https://github.com/pyproj4/pyproj
   license: OSI
   license_file: LICENSE
-  summary: 'Python interface to PROJ.4 library'
+  summary: 'Python interface to PROJ library'
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
The upstream PROJ conda-forge package has been renamed to `proj`, this should be reflected here. Otherwise new versions of PROJ is not picked up by `pyproj` (right now `pyproj` isn't using 6.2.0 because it is only available through the `proj` package and not the `proj4` package).

Additionally, the library name has officially changed from PROJ.4 to simply PROJ.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
