### PR TITLE
Enable ppc64le but disable PyPy for now

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,46 +8,54 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_numpy1.22python3.10.____cpython:
-        CONFIG: linux_64_numpy1.22python3.10.____cpython
+      linux_64_numpy1.22python3.10.____cpythonpython_implcpython:
+        CONFIG: linux_64_numpy1.22python3.10.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_numpy1.22python3.9.____73_pypy:
-        CONFIG: linux_64_numpy1.22python3.9.____73_pypy
+      linux_64_numpy1.22python3.9.____cpythonpython_implcpython:
+        CONFIG: linux_64_numpy1.22python3.9.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_numpy1.22python3.9.____cpython:
-        CONFIG: linux_64_numpy1.22python3.9.____cpython
+      linux_64_numpy1.23python3.11.____cpythonpython_implcpython:
+        CONFIG: linux_64_numpy1.23python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_numpy1.23python3.11.____cpython:
-        CONFIG: linux_64_numpy1.23python3.11.____cpython
+      linux_64_numpy1.26python3.12.____cpythonpython_implcpython:
+        CONFIG: linux_64_numpy1.26python3.12.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_numpy1.26python3.12.____cpython:
-        CONFIG: linux_64_numpy1.26python3.12.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_numpy1.22python3.10.____cpython:
-        CONFIG: linux_aarch64_numpy1.22python3.10.____cpython
+      linux_aarch64_numpy1.22python3.10.____cpythonpython_implcpython:
+        CONFIG: linux_aarch64_numpy1.22python3.10.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
-      linux_aarch64_numpy1.22python3.9.____73_pypy:
-        CONFIG: linux_aarch64_numpy1.22python3.9.____73_pypy
+      linux_aarch64_numpy1.22python3.9.____cpythonpython_implcpython:
+        CONFIG: linux_aarch64_numpy1.22python3.9.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
-      linux_aarch64_numpy1.22python3.9.____cpython:
-        CONFIG: linux_aarch64_numpy1.22python3.9.____cpython
+      linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython:
+        CONFIG: linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
-      linux_aarch64_numpy1.23python3.11.____cpython:
-        CONFIG: linux_aarch64_numpy1.23python3.11.____cpython
+      linux_aarch64_numpy1.26python3.12.____cpythonpython_implcpython:
+        CONFIG: linux_aarch64_numpy1.26python3.12.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
-      linux_aarch64_numpy1.26python3.12.____cpython:
-        CONFIG: linux_aarch64_numpy1.26python3.12.____cpython
+      linux_ppc64le_numpy1.22python3.10.____cpythonpython_implcpython:
+        CONFIG: linux_ppc64le_numpy1.22python3.10.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
+      linux_ppc64le_numpy1.22python3.9.____cpythonpython_implcpython:
+        CONFIG: linux_ppc64le_numpy1.22python3.9.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
+      linux_ppc64le_numpy1.23python3.11.____cpythonpython_implcpython:
+        CONFIG: linux_ppc64le_numpy1.23python3.11.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
+      linux_ppc64le_numpy1.26python3.12.____cpythonpython_implcpython:
+        CONFIG: linux_ppc64le_numpy1.26python3.12.____cpythonpython_implcpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-ppc64le
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,20 +8,17 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_numpy1.22python3.10.____cpython:
-        CONFIG: osx_64_numpy1.22python3.10.____cpython
+      osx_64_numpy1.22python3.10.____cpythonpython_implcpython:
+        CONFIG: osx_64_numpy1.22python3.10.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.22python3.9.____73_pypy:
-        CONFIG: osx_64_numpy1.22python3.9.____73_pypy
+      osx_64_numpy1.22python3.9.____cpythonpython_implcpython:
+        CONFIG: osx_64_numpy1.22python3.9.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.22python3.9.____cpython:
-        CONFIG: osx_64_numpy1.22python3.9.____cpython
+      osx_64_numpy1.23python3.11.____cpythonpython_implcpython:
+        CONFIG: osx_64_numpy1.23python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.23python3.11.____cpython:
-        CONFIG: osx_64_numpy1.23python3.11.____cpython
-        UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.26python3.12.____cpython:
-        CONFIG: osx_64_numpy1.26python3.12.____cpython
+      osx_64_numpy1.26python3.12.____cpythonpython_implcpython:
+        CONFIG: osx_64_numpy1.26python3.12.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
       osx_arm64_numpy1.22python3.10.____cpython:
         CONFIG: osx_arm64_numpy1.22python3.10.____cpython

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,20 +8,17 @@ jobs:
     vmImage: windows-2022
   strategy:
     matrix:
-      win_64_numpy1.22python3.10.____cpython:
-        CONFIG: win_64_numpy1.22python3.10.____cpython
+      win_64_numpy1.22python3.10.____cpythonpython_implcpython:
+        CONFIG: win_64_numpy1.22python3.10.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-      win_64_numpy1.22python3.9.____73_pypy:
-        CONFIG: win_64_numpy1.22python3.9.____73_pypy
+      win_64_numpy1.22python3.9.____cpythonpython_implcpython:
+        CONFIG: win_64_numpy1.22python3.9.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-      win_64_numpy1.22python3.9.____cpython:
-        CONFIG: win_64_numpy1.22python3.9.____cpython
+      win_64_numpy1.23python3.11.____cpythonpython_implcpython:
+        CONFIG: win_64_numpy1.23python3.11.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
-      win_64_numpy1.23python3.11.____cpython:
-        CONFIG: win_64_numpy1.23python3.11.____cpython
-        UPLOAD_PACKAGES: 'True'
-      win_64_numpy1.26python3.12.____cpython:
-        CONFIG: win_64_numpy1.26python3.12.____cpython
+      win_64_numpy1.26python3.12.____cpythonpython_implcpython:
+        CONFIG: win_64_numpy1.26python3.12.____cpythonpython_implcpython
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -1,17 +1,17 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '15'
+- '12'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-macos_machine:
-- x86_64-apple-darwin13.4.0
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
-- '1.23'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -19,10 +19,12 @@ pin_run_as_build:
 proj:
 - 9.3.0
 python:
-- 3.11.* *_cpython
+- 3.10.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/linux_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -1,17 +1,17 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '15'
+- '12'
+cdt_name:
+- cos6
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
-macos_machine:
-- x86_64-apple-darwin13.4.0
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
-- '1.26'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -19,10 +19,12 @@ pin_run_as_build:
 proj:
 - 9.3.0
 python:
-- 3.12.* *_cpython
+- 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- osx-64
+- linux-64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/linux_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -1,21 +1,17 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '12'
-cdt_arch:
-- aarch64
 cdt_name:
-- cos7
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
-- '1.22'
+- '1.23'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -23,10 +19,12 @@ pin_run_as_build:
 proj:
 - 9.3.0
 python:
-- 3.10.* *_cpython
+- 3.11.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- linux-aarch64
+- linux-64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/linux_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -11,7 +11,7 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
-- '1.22'
+- '1.26'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -19,10 +19,12 @@ pin_run_as_build:
 proj:
 - 9.3.0
 python:
-- 3.10.* *_cpython
+- 3.12.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -23,10 +23,12 @@ pin_run_as_build:
 proj:
 - 9.3.0
 python:
-- 3.9.* *_73_pypy
+- 3.10.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-aarch64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -1,17 +1,21 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+cdt_arch:
+- aarch64
 cdt_name:
-- cos6
+- cos7
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-aarch64
 numpy:
-- '1.26'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -19,10 +23,12 @@ pin_run_as_build:
 proj:
 - 9.3.0
 python:
-- 3.12.* *_cpython
+- 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -1,17 +1,21 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+cdt_arch:
+- aarch64
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-aarch64
 numpy:
-- '1.22'
+- '1.23'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -19,10 +23,12 @@ pin_run_as_build:
 proj:
 - 9.3.0
 python:
-- 3.9.* *_cpython
+- 3.11.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -15,7 +15,7 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64
 numpy:
-- '1.22'
+- '1.26'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -23,10 +23,12 @@ pin_run_as_build:
 proj:
 - 9.3.0
 python:
-- 3.9.* *_cpython
+- 3.12.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-aarch64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -1,9 +1,15 @@
 c_compiler:
-- vs2019
+- gcc
+c_compiler_version:
+- '12'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -13,10 +19,12 @@ pin_run_as_build:
 proj:
 - 9.3.0
 python:
-- 3.9.* *_cpython
+- 3.10.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- win-64
+- linux-ppc64le
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -3,15 +3,15 @@ c_compiler:
 c_compiler_version:
 - '12'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-ppc64le
 numpy:
-- '1.23'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -19,10 +19,12 @@ pin_run_as_build:
 proj:
 - 9.3.0
 python:
-- 3.11.* *_cpython
+- 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- linux-64
+- linux-ppc64le
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -1,17 +1,17 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '15'
+- '12'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-macos_machine:
-- x86_64-apple-darwin13.4.0
+docker_image:
+- quay.io/condaforge/linux-anvil-ppc64le
 numpy:
-- '1.22'
+- '1.23'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -19,10 +19,12 @@ pin_run_as_build:
 proj:
 - 9.3.0
 python:
-- 3.9.* *_cpython
+- 3.11.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- osx-64
+- linux-ppc64le
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -1,19 +1,15 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
 - '12'
-cdt_arch:
-- aarch64
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64
+- quay.io/condaforge/linux-anvil-ppc64le
 numpy:
 - '1.26'
 pin_run_as_build:
@@ -24,9 +20,11 @@ proj:
 - 9.3.0
 python:
 - 3.12.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- linux-aarch64
+- linux-ppc64le
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/migrations/proj930.yaml
+++ b/.ci_support/migrations/proj930.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1693581350.7818532
-proj:
-- 9.3.0

--- a/.ci_support/osx_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -1,9 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- vs2019
+- clang
+c_compiler_version:
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -14,9 +20,11 @@ proj:
 - 9.3.0
 python:
 - 3.10.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- win-64
+- osx-64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/osx_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -1,9 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- vs2019
+- clang
+c_compiler_version:
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -13,10 +19,12 @@ pin_run_as_build:
 proj:
 - 9.3.0
 python:
-- 3.9.* *_73_pypy
+- 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- win-64
+- osx-64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -1,17 +1,17 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
-cdt_name:
-- cos6
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
-- '1.22'
+- '1.23'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -19,10 +19,12 @@ pin_run_as_build:
 proj:
 - 9.3.0
 python:
-- 3.9.* *_73_pypy
+- 3.11.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/osx_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/osx_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -1,21 +1,17 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '12'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-docker_image:
-- quay.io/condaforge/linux-anvil-aarch64
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
-- '1.23'
+- '1.26'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -23,10 +19,12 @@ pin_run_as_build:
 proj:
 - 9.3.0
 python:
-- 3.11.* *_cpython
+- 3.12.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- linux-aarch64
+- osx-64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.10.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -20,9 +20,11 @@ proj:
 - 9.3.0
 python:
 - 3.10.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-arm64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.22python3.9.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -20,9 +20,11 @@ proj:
 - 9.3.0
 python:
 - 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-arm64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.23python3.11.____cpython.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -20,9 +20,11 @@ proj:
 - 9.3.0
 python:
 - 3.11.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-arm64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.26python3.12.____cpython.yaml
@@ -3,9 +3,9 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 macos_machine:
@@ -20,9 +20,11 @@ proj:
 - 9.3.0
 python:
 - 3.12.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-arm64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/win_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.10.____cpythonpython_implcpython.yaml
@@ -1,15 +1,9 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
-c_compiler_version:
-- '15'
+- vs2019
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
 - '1.22'
 pin_run_as_build:
@@ -19,10 +13,12 @@ pin_run_as_build:
 proj:
 - 9.3.0
 python:
-- 3.9.* *_73_pypy
+- 3.10.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- osx-64
+- win-64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/win_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.22python3.9.____cpythonpython_implcpython.yaml
@@ -1,11 +1,11 @@
 c_compiler:
 - vs2019
 channel_sources:
-- conda-forge/label/python_rc,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 numpy:
-- '1.26'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -13,10 +13,12 @@ pin_run_as_build:
 proj:
 - 9.3.0
 python:
-- 3.12.* *_cpython
+- 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - win-64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/win_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.23python3.11.____cpythonpython_implcpython.yaml
@@ -14,9 +14,11 @@ proj:
 - 9.3.0
 python:
 - 3.11.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - win-64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.ci_support/win_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
+++ b/.ci_support/win_64_numpy1.26python3.12.____cpythonpython_implcpython.yaml
@@ -1,17 +1,11 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
 c_compiler:
-- clang
-c_compiler_version:
-- '15'
+- vs2019
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-macos_machine:
-- x86_64-apple-darwin13.4.0
 numpy:
-- '1.22'
+- '1.26'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -19,10 +13,12 @@ pin_run_as_build:
 proj:
 - 9.3.0
 python:
-- 3.10.* *_cpython
+- 3.12.* *_cpython
+python_impl:
+- cpython
 target_platform:
-- osx-64
+- win-64
 zip_keys:
 - - python
   - numpy
-  - channel_sources
+  - python_impl

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,7 +34,7 @@ CONDARC
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
     pip mamba conda-build boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,7 +26,7 @@ conda activate base
 mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
     pip mamba conda-build boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 
 

--- a/README.md
+++ b/README.md
@@ -27,108 +27,115 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_numpy1.22python3.10.____cpython</td>
+              <td>linux_64_numpy1.22python3.10.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.10.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.22python3.9.____73_pypy</td>
+              <td>linux_64_numpy1.22python3.9.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.9.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.9.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.22python3.9.____cpython</td>
+              <td>linux_64_numpy1.23python3.11.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.22python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.23python3.11.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.23python3.11.____cpython</td>
+              <td>linux_64_numpy1.26python3.12.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.26python3.12.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_numpy1.26python3.12.____cpython</td>
+              <td>linux_aarch64_numpy1.22python3.10.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.26python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.22python3.10.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.22python3.10.____cpython</td>
+              <td>linux_aarch64_numpy1.22python3.9.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.22python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.22python3.9.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.22python3.9.____73_pypy</td>
+              <td>linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.22python3.9.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.23python3.11.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.22python3.9.____cpython</td>
+              <td>linux_aarch64_numpy1.26python3.12.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.22python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.26python3.12.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.23python3.11.____cpython</td>
+              <td>linux_ppc64le_numpy1.22python3.10.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_numpy1.22python3.10.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_numpy1.26python3.12.____cpython</td>
+              <td>linux_ppc64le_numpy1.22python3.9.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.26python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_numpy1.22python3.9.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.22python3.10.____cpython</td>
+              <td>linux_ppc64le_numpy1.23python3.11.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_numpy1.23python3.11.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.22python3.9.____73_pypy</td>
+              <td>linux_ppc64le_numpy1.26python3.12.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.9.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_numpy1.26python3.12.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.22python3.9.____cpython</td>
+              <td>osx_64_numpy1.22python3.10.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.10.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.23python3.11.____cpython</td>
+              <td>osx_64_numpy1.22python3.9.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.23python3.11.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.22python3.9.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.26python3.12.____cpython</td>
+              <td>osx_64_numpy1.23python3.11.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.26python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.23python3.11.____cpythonpython_implcpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.26python3.12.____cpythonpython_implcpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.26python3.12.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -160,38 +167,31 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.22python3.10.____cpython</td>
+              <td>win_64_numpy1.22python3.10.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.22python3.10.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.22python3.10.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.22python3.9.____73_pypy</td>
+              <td>win_64_numpy1.22python3.9.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.22python3.9.____73_pypy" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.22python3.9.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.22python3.9.____cpython</td>
+              <td>win_64_numpy1.23python3.11.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.22python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.23python3.11.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.23python3.11.____cpython</td>
+              <td>win_64_numpy1.26python3.12.____cpythonpython_implcpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.23python3.11.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>win_64_numpy1.26python3.12.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=911&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.26python3.12.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pyproj-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.26python3.12.____cpythonpython_implcpython" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,9 @@ source:
   sha256: 44aa7c704c2b7d8fb3d483bbf75af6cb2350d30a63b144279a09b75fead501bf
 
 build:
-  number: 2
+  number: 3
   # we will figure out the ppc64le failures in a subsequent PR
-  skip: true  # [py<39 or ppc64le]
+  skip: true  # [py<39 or python_impl == 'pypy']
   entry_points:
     - pyproj=pyproj.__main__:main
   script_env:


### PR DESCRIPTION
We have fixed ppc64le in proj by building with newer compilers. Tests are currently failing with PyPy and we will investigate in a follow-up build.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
